### PR TITLE
Stop Dependabot raising dependency floors that change nothing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
   # graph, docs, test and dev extras.
   - package-ecosystem: "pip"
     directory: "/"
+    # This is a library, not an application, and its constraints are open
+    # ranges. Under the default strategy Dependabot raises the *floor* of every
+    # `>=` whenever a release appears -- proposing `pytest>=9.1.1` in place of
+    # `pytest>=8.0` even though 9.1.1 already satisfies the old range and is
+    # what CI installs. Those bumps test nothing new; they only drop support for
+    # older versions. `increase-if-necessary` keeps the range alone until a
+    # release genuinely falls outside it, which is when a bump carries
+    # information.
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "monday"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -348,6 +348,15 @@ hooks use the same ones. This is not fussiness: ruff 0.15 and 0.16 disagree abou
 and no source file can satisfy both. A range would make `make quality` pass or fail
 depending on what a contributor happened to have installed.
 
+**Everything else is an open `>=` range, and stays that way.** A floor states the oldest
+version believed to work, not the newest available — CI already installs the newest, so
+raising a floor tests nothing and only drops support. Dependabot is therefore configured
+with `versioning-strategy: increase-if-necessary` for pip, so it proposes a bump only when
+a release actually falls outside the declared range. The exceptions are **upper** bounds on
+the three documentation packages, which exist because the site is built with `--strict`: a
+major release that renames an option would otherwise turn a dependency update into a red
+build.
+
 ---
 
 ## 7. Versioning and compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,11 @@ docs = [
     # and mkdocstrings with no migration path. Pinned until that shakes out.
     "mkdocs>=1.6,<2",
     "mkdocs-material>=9.5,<10",
-    "mkdocstrings[python]>=0.26",
+    # Bounded for the same reason as its neighbours, which it was missing: the
+    # docs site is built with `--strict`, so a major release that renames an
+    # option turns a dependency update into a red build. 1.0 is current and
+    # works; the cap is against 2.0, unseen.
+    "mkdocstrings[python]>=0.26,<2",
 ]
 test = [
     "dafsa[graph]",


### PR DESCRIPTION
Supersedes the ten open pip Dependabot PRs (#20, #22–#30), and fixes the one real gap they
brought to light.

## What those PRs propose

Every one is a lower-bound bump on an open range: `pytest>=8.0` → `>=9.1.1`,
`networkx>=3.0` → `>=3.4.2`, and so on. None changes an upper bound; none changes what gets
installed.

That last point is the crux. CI runs `pip install -e ".[test]"`, which already resolves to
the newest compatible release. The current environment demonstrates it — every package sits
at or above the floor Dependabot wants, under the *existing* constraints:

| package | floor proposed | installed under today's range |
|---|---|---|
| `pytest` | `>=9.1.1` | 9.1.1 |
| `pytest-cov` | `>=7.1.0` | 7.1.0 |
| `hypothesis` | `>=6.161.7` | 6.163.0 |
| `networkx` | `>=3.4.2` | 3.6.1 |
| `mkdocstrings` | `>=1.0.6` | 1.0.6 |
| `mkdocs-material` | `>=9.7.7` | 9.7.7 |
| `bandit` | `>=1.9.4` | 1.9.4 |

The suite passes on exactly these versions. Merging the bumps would not test one thing that
is not already tested; it would only stop the package installing on older ones — and
`networkx` is in the `graph` extra, so that cost lands on users, not just contributors. The
three functions using it (`MultiDiGraph`, `write_gml`, `write_graphml`) have been stable
since long before 3.0.

A floor should state the oldest version believed to work. Pinning it to the newest available
converts it into a changelog that nobody reads and that narrows support every week.

## The fix

`versioning-strategy: increase-if-necessary` for pip in `.github/dependabot.yml`. Dependabot
then proposes a bump only when a release genuinely falls outside the declared range — which
is when the bump carries information. Security advisories are unaffected: those are raised
regardless of strategy.

## The gap worth keeping

`#24` bumps `mkdocstrings` across a **major** release, 0.26 → 1.0. The floor is the wrong
half of that observation: `mkdocs` and `mkdocs-material` both carry `<2` and `<10` caps
precisely because the site builds with `--strict` and a renamed option turns a dependency
update into a red build. `mkdocstrings` had no cap at all, so 2.0 would have been picked up
silently. It now reads `>=0.26,<2`, matching its neighbours. The docs build is verified
against the 1.0.6 currently installed.

`ARCHITECTURE.md` records the policy so the next person does not undo it.

## Not superseded

**#21** (`actions/deploy-pages` 4 → 5) is a different case — an exact `@v4` pin, where a bump
is the only way to move, and the strategy above does not apply to the `github-actions`
ecosystem. It should be merged on its own. It touches `.github/workflows/docs.yml`, which
this session's credentials cannot modify, so it needs a human hand. Worth noting `docs.yml`
only runs on push to `master`, so the PR's own checks do not exercise the change; the deploy
is the first real test of it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeHexzwFiGrTsR6DjMzx1M)_