### PR TITLE
Fix the version bump target and stamp the release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0
+## 2.0.0 — 2026-08-04
 
 A rewrite. 2.0 shares no implementation with 1.0 and its API is a deliberate break; `dafsa==1.0`
 stays on PyPI, and the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,8 @@ authors:
     email: dafsa@tresoldi.org
     orcid: "https://orcid.org/0000-0002-2863-1467"
 version: 2.0.0
+# Stamped by `make bump-version`; set by hand for the 2.0.0 release itself.
+date-released: 2026-08-04
 license: MIT
 doi: 10.5281/zenodo.3668870
 repository-code: "https://github.com/tresoldi/dafsa"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # dafsa Makefile
 # POSIX-compatible development commands
 
-.PHONY: help quality security format test test-cov test-fast bump-version build build-release clean install install-dev bench site site-serve
+.PHONY: help quality security format test test-cov test-fast version bump-version build build-release clean install install-dev bench site site-serve
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -61,8 +61,17 @@ test-fast: ## Run tests in parallel, skipping the slow performance guards
 	pytest -n auto -m "not slow" --no-cov
 	@echo "OK: tests passed."
 
-bump-version: ## Bump version (TYPE=patch|minor|major) in pyproject.toml, commit, and tag
-	@CURRENT=$$(grep -m1 -o '^version = "[^"]*"' pyproject.toml | cut -d'"' -f2); \
+# The version lives in src/dafsa/__init__.py, which pyproject.toml reads through
+# `dynamic`. CITATION.cff carries a copy, and its date-released is stamped here
+# so the citation metadata cannot claim a date the release did not have.
+VERSION_FILE := src/dafsa/__init__.py
+
+version: ## Print the current version
+	@grep -m1 -o '^__version__ = "[^"]*"' $(VERSION_FILE) | cut -d'"' -f2
+
+bump-version: ## Bump version (TYPE=patch|minor|major), stamp CITATION.cff, commit, and tag
+	@CURRENT=$$(grep -m1 -o '^__version__ = "[^"]*"' $(VERSION_FILE) | cut -d'"' -f2); \
+	if [ -z "$$CURRENT" ]; then echo "Error: no __version__ found in $(VERSION_FILE)"; exit 1; fi; \
 	echo "==> Current version: $$CURRENT"; \
 	major=$$(echo $$CURRENT | cut -d. -f1); \
 	minor=$$(echo $$CURRENT | cut -d. -f2); \
@@ -71,22 +80,23 @@ bump-version: ## Bump version (TYPE=patch|minor|major) in pyproject.toml, commit
 	elif [ "$(TYPE)" = "minor" ]; then NEW="$$major.$$((minor + 1)).0"; \
 	elif [ "$(TYPE)" = "patch" ]; then NEW="$$major.$$minor.$$((patch + 1))"; \
 	else echo "Error: TYPE must be patch, minor, or major"; exit 1; fi; \
-	echo "==> Bumping $(TYPE) version to $$NEW..."; \
-	sed -i "s/^version = \"$$CURRENT\"/version = \"$$NEW\"/" pyproject.toml; \
-	sed -i "s/^version: $$CURRENT/version: $$NEW/" CITATION.cff; \
+	TODAY=$$(date +%Y-%m-%d); \
+	echo "==> Bumping $(TYPE) version to $$NEW, released $$TODAY..."; \
+	sed -i.bak "s/^__version__ = \"$$CURRENT\"/__version__ = \"$$NEW\"/" $(VERSION_FILE); \
+	sed -i.bak -e "s/^version: .*/version: $$NEW/" \
+	           -e "s/^date-released: .*/date-released: $$TODAY/" CITATION.cff; \
+	rm -f $(VERSION_FILE).bak CITATION.cff.bak; \
 	echo ""; \
-	echo "Update CHANGELOG.md before committing."; \
+	echo "Now update CHANGELOG.md, then press Enter to commit and tag."; \
 	echo ""; \
-	read -p "Press Enter to commit and tag, or Ctrl+C to cancel..."; \
-	git add pyproject.toml CITATION.cff; \
-	git commit -m "Bump version to $$NEW"; \
+	read -p "Press Enter to continue, or Ctrl+C to cancel..."; \
+	git add $(VERSION_FILE) CITATION.cff CHANGELOG.md; \
+	git commit -m "Release $$NEW"; \
 	git tag -a "v$$NEW" -m "Release v$$NEW"; \
 	echo "OK: version bumped to $$NEW and tagged."; \
 	echo ""; \
-	echo "Next steps:"; \
-	echo "  1. Update CHANGELOG.md"; \
-	echo "  2. git add CHANGELOG.md && git commit --amend --no-edit"; \
-	echo "  3. git push && git push --tags"
+	echo "Next step:  git push && git push --tags"; \
+	echo "The release workflow publishes to PyPI on the tag."
 
 build: ## Build the package (creates dist/)
 	@echo "==> Building package..."


### PR DESCRIPTION
Two things found while checking what a 2.0.0 release still needs.

## `make bump-version` was broken

It read the version out of `pyproject.toml`:

```make
CURRENT=$(grep -m1 -o '^version = "[^"]*"' pyproject.toml | cut -d'"' -f2)
```

There is no such line any more — `pyproject.toml` declares `dynamic = ["version"]` and reads
it from `dafsa.__version__`. That was my change, and I did not update the target with it, so
`CURRENT` came back empty, the `sed` matched nothing, and the target would have committed an
unchanged tree and tagged it `v..1`.

It now reads and writes `src/dafsa/__init__.py`, the single source. Two further fixes while
in there:

- `sed -i` with no suffix is GNU-only and fails on macOS. Now `sed -i.bak` plus a cleanup,
  which works on both.
- `CHANGELOG.md` is staged with the commit rather than left for an `--amend` afterwards, so
  the release commit is complete the first time.

Exercised end to end in a throwaway clone rather than assumed: `2.0.0` → `2.1.0`, both files
rewritten, commit and `v2.1.0` tag created.

Also adds `make version`, which prints the current version — useful on its own and the thing
the release checklist wants to confirm.

## Release metadata had no date

`CITATION.cff` had no `date-released` at all, and the `CHANGELOG` heading was a bare
`## 2.0.0`. Both now carry `2026-08-04`, and `bump-version` stamps `date-released` from
`date +%Y-%m-%d` on every future release so the citation metadata cannot drift from reality.

**Adjust both dates if the tag lands on a different day.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01HeHexzwFiGrTsR6DjMzx1M)_